### PR TITLE
Fix ClawHub publishing and Maya antivirus discovery

### DIFF
--- a/.github/scripts/validate_clawhub_publish.py
+++ b/.github/scripts/validate_clawhub_publish.py
@@ -1,0 +1,128 @@
+"""Validate the structured receipt emitted by a pinned ClawHub CLI publish."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+
+EXPECTED_STATUSES = {
+    "dry-run": frozenset({"unchanged", "would-publish"}),
+    "publish": frozenset({"unchanged", "published", "pending-publication", "submitted"}),
+}
+FINGERPRINT_PATTERN = re.compile(r"[0-9a-f]{64}")
+
+
+class ReceiptError(ValueError):
+    """Raised when a ClawHub receipt cannot prove the requested operation."""
+
+
+def _require_nonempty_string(payload: dict[str, Any], field: str) -> str:
+    value = payload.get(field)
+    if not isinstance(value, str) or not value.strip():
+        raise ReceiptError(f"ClawHub receipt is missing {field}")
+    return value
+
+
+def validate_receipt(
+    payload: Any,
+    mode: str,
+    expected_slug: str,
+    preview: Any | None = None,
+) -> dict[str, Any]:
+    """Return a validated receipt or fail closed on an unknown result contract."""
+    if mode not in EXPECTED_STATUSES:
+        raise ReceiptError(f"Unknown validation mode: {mode!r}")
+    if not isinstance(payload, dict):
+        raise ReceiptError("ClawHub receipt must be a JSON object")
+    if payload.get("ok") is not True:
+        raise ReceiptError("ClawHub receipt did not report ok=true")
+
+    slug = payload.get("slug")
+    if slug != expected_slug:
+        raise ReceiptError(f"ClawHub receipt slug {slug!r} does not match {expected_slug!r}")
+
+    status = payload.get("status")
+    allowed = EXPECTED_STATUSES[mode]
+    if not isinstance(status, str) or status not in allowed:
+        raise ReceiptError(
+            f"ClawHub status {status!r} is not valid for {mode}; expected one of {sorted(allowed)}"
+        )
+
+    version = _require_nonempty_string(payload, "version")
+    fingerprint = _require_nonempty_string(payload, "fingerprint")
+    if FINGERPRINT_PATTERN.fullmatch(fingerprint) is None:
+        raise ReceiptError("ClawHub receipt fingerprint must be 64 lowercase hex characters")
+
+    file_count = payload.get("fileCount")
+    if isinstance(file_count, bool) or not isinstance(file_count, int) or file_count <= 0:
+        raise ReceiptError("ClawHub receipt fileCount must be a positive integer")
+
+    if "latestVersion" not in payload:
+        raise ReceiptError("ClawHub receipt is missing latestVersion")
+    latest_version = payload["latestVersion"]
+    if latest_version is not None and (
+        not isinstance(latest_version, str) or not latest_version.strip()
+    ):
+        raise ReceiptError("ClawHub receipt latestVersion must be a version or null")
+    if status == "unchanged" and latest_version != version:
+        raise ReceiptError(
+            "Unchanged receipt does not match the public latestVersion; "
+            "the matching bundle may be pending or historical"
+        )
+
+    if status == "pending-publication":
+        if payload.get("publicationStatus") != "pending":
+            raise ReceiptError("Pending publication receipt must report publicationStatus=pending")
+        _require_nonempty_string(payload, "versionId")
+        # Repository policy requires a moderation handle even though the CLI type is optional.
+        _require_nonempty_string(payload, "attemptId")
+    elif status == "published":
+        if payload.get("publicationStatus") != "published":
+            raise ReceiptError("Published receipt must report publicationStatus=published")
+        _require_nonempty_string(payload, "versionId")
+    elif status == "submitted":
+        _require_nonempty_string(payload, "versionId")
+
+    if preview is not None:
+        validated_preview = validate_receipt(preview, "dry-run", expected_slug)
+        for field in ("slug", "version", "fingerprint", "fileCount"):
+            if payload.get(field) != validated_preview.get(field):
+                raise ReceiptError(f"ClawHub receipt {field} does not match the dry-run preview")
+    return payload
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("receipt", type=Path)
+    parser.add_argument("--mode", choices=tuple(EXPECTED_STATUSES), required=True)
+    parser.add_argument("--expected-slug", required=True)
+    parser.add_argument("--preview", type=Path)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        payload = json.loads(args.receipt.read_text(encoding="utf-8"))
+        preview = (
+            json.loads(args.preview.read_text(encoding="utf-8")) if args.preview else None
+        )
+        if args.mode == "publish" and preview is None:
+            raise ReceiptError("Publish validation requires the dry-run preview")
+        receipt = validate_receipt(payload, args.mode, args.expected_slug, preview)
+    except (OSError, json.JSONDecodeError, ReceiptError) as error:
+        raise SystemExit(f"Invalid ClawHub publish receipt: {error}") from error
+
+    print(
+        "ClawHub receipt accepted: "
+        f"{receipt['slug']}@{receipt['version']} status={receipt['status']} mode={args.mode}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/clawhub-skill.yml
+++ b/.github/workflows/clawhub-skill.yml
@@ -5,34 +5,160 @@ on:
     paths:
       - "plugin.json"
       - "skills/maya-umbrella-batch-antivirus/**"
+      - ".github/scripts/validate_clawhub_publish.py"
       - ".github/workflows/clawhub-skill.yml"
+  release:
+    types: [published]
   workflow_dispatch:
 
 concurrency:
-  group: clawhub-skill-${{ github.workflow }}-${{ github.ref }}
+  group: clawhub-skill-${{ github.event_name == 'pull_request' && github.ref || 'publish' }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  dry-run:
-    if: ${{ github.event_name == 'pull_request' }}
-    permissions:
-      contents: read
-      id-token: write
-    uses: openclaw/clawhub/.github/workflows/skill-publish.yml@36d26c73f42b98ec690352ed2767d0ca7cd78130
-    with:
-      skill_path: skills/maya-umbrella-batch-antivirus
-      owner: loonghao
-      dry_run: true
-
   publish:
-    if: ${{ github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.event_name != 'release' || github.event.release.prerelease == false }}
+    name: ${{ github.event_name == 'pull_request' && 'Dry run' || 'Publish' }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
     permissions:
       contents: read
-      id-token: write
-    uses: openclaw/clawhub/.github/workflows/skill-publish.yml@36d26c73f42b98ec690352ed2767d0ca7cd78130
-    with:
-      skill_path: skills/maya-umbrella-batch-antivirus
-      owner: loonghao
-      dry_run: false
-    secrets:
-      clawhub_token: ${{ secrets.CLAWHUB_TOKEN }}
+    env:
+      CLAWHUB_CLI_VERSION: "0.23.3"
+      CLAWHUB_DISABLE_TELEMETRY: "1"
+      SKILL_PATH: skills/maya-umbrella-batch-antivirus
+      SKILL_SLUG: maya-umbrella-batch-antivirus
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: Set up Node.js 22
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "22"
+      - name: Install pinned ClawHub CLI
+        shell: bash
+        run: |
+          npm install --global --ignore-scripts --no-audit --no-fund \
+            "clawhub@$CLAWHUB_CLI_VERSION"
+          [[ "$(clawhub --cli-version)" == "$CLAWHUB_CLI_VERSION" ]]
+      - name: Verify source provenance
+        shell: bash
+        run: |
+          [[ "$(git rev-parse HEAD)" == "$GITHUB_SHA" ]]
+          [[ -z "$(git status --short)" ]]
+      - name: Require merged manual publish source
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        shell: bash
+        run: |
+          if [[ "$GITHUB_REF" != "refs/heads/main" ]]; then
+            echo "::error::Manual ClawHub publishes must run from refs/heads/main."
+            exit 1
+          fi
+      - name: Require publish credentials
+        if: ${{ github.event_name != 'pull_request' }}
+        env:
+          CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}
+        shell: bash
+        run: |
+          if [[ -z "$CLAWHUB_TOKEN" ]]; then
+            echo "::error::Real ClawHub publishes require the CLAWHUB_TOKEN repository secret."
+            exit 1
+          fi
+      - name: Write ephemeral ClawHub configuration
+        if: ${{ github.event_name != 'pull_request' }}
+        env:
+          CLAWHUB_CONFIG_PATH: ${{ runner.temp }}/clawhub-config.json
+          CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}
+        shell: bash
+        run: |
+          node <<'NODE'
+          const fs = require("node:fs");
+          fs.writeFileSync(
+            process.env.CLAWHUB_CONFIG_PATH,
+            JSON.stringify({ registry: "https://clawhub.ai", token: process.env.CLAWHUB_TOKEN }) + "\n",
+            { mode: 0o600 },
+          );
+          NODE
+      - name: Preview and optionally publish the Skill
+        env:
+          CLAWHUB_CONFIG_PATH: ${{ runner.temp }}/clawhub-config.json
+          PUBLISH: ${{ github.event_name != 'pull_request' }}
+          PREVIEW_PATH: ${{ runner.temp }}/clawhub-preview.json
+          RECEIPT_PATH: ${{ runner.temp }}/clawhub-publish.json
+        shell: bash
+        run: |
+          args=(
+            skill publish "$SKILL_PATH"
+            --owner loonghao
+            --tags latest
+            --source-repo "$GITHUB_REPOSITORY"
+            --source-commit "$GITHUB_SHA"
+            --source-ref "$GITHUB_REF"
+            --source-path "$SKILL_PATH"
+            --json
+          )
+
+          clawhub "${args[@]}" --dry-run > "$PREVIEW_PATH"
+          python3 .github/scripts/validate_clawhub_publish.py \
+            "$PREVIEW_PATH" \
+            --mode dry-run \
+            --expected-slug "$SKILL_SLUG"
+
+          if [[ "$PUBLISH" != "true" ]]; then
+            cp "$PREVIEW_PATH" "$RECEIPT_PATH"
+            exit 0
+          fi
+
+          if node -e '
+            const receipt = require(process.env.PREVIEW_PATH);
+            const publiclyCurrent =
+              receipt.status === "unchanged" && receipt.version === receipt.latestVersion;
+            process.exit(publiclyCurrent ? 0 : 1);
+          '; then
+            cp "$PREVIEW_PATH" "$RECEIPT_PATH"
+            exit 0
+          fi
+
+          publish_version="$(node -p 'require(process.env.PREVIEW_PATH).version')"
+          catalog_args=()
+          if node -e '
+            const receipt = require(process.env.PREVIEW_PATH);
+            const firstPublish = receipt.status === "would-publish" && receipt.latestVersion === null;
+            process.exit(firstPublish ? 0 : 1);
+          '; then
+            catalog_args=(
+              --categories security,operations
+              --topics maya,antivirus,malware,virus-scan,scene-cleanup
+            )
+          fi
+
+          clawhub "${args[@]}" --version "$publish_version" \
+            "${catalog_args[@]}" > "$RECEIPT_PATH"
+      - name: Validate ClawHub receipt
+        env:
+          MODE: ${{ github.event_name == 'pull_request' && 'dry-run' || 'publish' }}
+          PREVIEW_PATH: ${{ runner.temp }}/clawhub-preview.json
+          RECEIPT_PATH: ${{ runner.temp }}/clawhub-publish.json
+        shell: bash
+        run: |
+          python3 .github/scripts/validate_clawhub_publish.py \
+            "$RECEIPT_PATH" \
+            --mode "$MODE" \
+            --expected-slug "$SKILL_SLUG" \
+            --preview "$PREVIEW_PATH"
+      - name: Remove ephemeral ClawHub configuration
+        if: ${{ always() && github.event_name != 'pull_request' }}
+        env:
+          CLAWHUB_CONFIG_PATH: ${{ runner.temp }}/clawhub-config.json
+        shell: bash
+        run: rm -f -- "$CLAWHUB_CONFIG_PATH"
+      - name: Preserve ClawHub receipt
+        if: ${{ always() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: clawhub-${{ github.event_name }}-${{ github.run_id }}
+          path: |
+            ${{ runner.temp }}/clawhub-preview.json
+            ${{ runner.temp }}/clawhub-publish.json
+          if-no-files-found: warn
+          retention-days: 30

--- a/README.md
+++ b/README.md
@@ -89,11 +89,13 @@ ClawHub 分发的是 Skill 子目录，不是仅含根 `plugin.json` 的完整 A
 ```powershell
 npx --yes clawhub@0.23.3 skill publish .\skills\maya-umbrella-batch-antivirus `
   --owner loonghao `
+  --categories security,operations `
+  --topics maya,antivirus,malware,virus-scan,scene-cleanup `
   --dry-run `
   --json
 ```
 
-正式发布前先执行 `npx --yes clawhub@0.23.3 login`；随后从上述命令移除 `--dry-run`，或在 GitHub Actions 手动运行 `ClawHub Skill` workflow（需要仓库 secret `CLAWHUB_TOKEN`）。公开版本通过安全审核并可见后，可通过 CLI 安装：
+正式发布前先执行 `npx --yes clawhub@0.23.3 login`。仓库配置 `CLAWHUB_TOKEN` secret 后，每个正式（非 prerelease）GitHub Release 会自动运行 `ClawHub Skill` workflow；`workflow_dispatch` 仅允许从 `main` 手动首发或受控补发。工作流固定使用 ClawHub CLI 0.23.3，首次发布时设置 `security,operations` 分类与检索 topics，后续同步省略这两个参数以保持内容未变化时的幂等性。它保存结构化回执，并把 `pending-publication` 或 `submitted` 作为“已提交、等待公开验证”，而不是误报成上传失败。公开版本通过安全审核并可见后，可通过 CLI 安装：
 
 ```powershell
 openclaw skills install @loonghao/maya-umbrella-batch-antivirus

--- a/skills/maya-umbrella-batch-antivirus/SKILL.md
+++ b/skills/maya-umbrella-batch-antivirus/SKILL.md
@@ -1,11 +1,20 @@
 ---
 name: maya-umbrella-batch-antivirus
-description: Scan and clean batches of Autodesk Maya .ma and .mb files on Windows with Maya Umbrella; use for suspected Maya malware or explicitly requested batch remediation, not general-purpose antivirus work.
+description: Scan/clean Maya scene malware on Windows. Use for Maya杀毒, Maya病毒扫描, Maya病毒查杀, 清理Maya病毒, 病毒查杀, Maya antivirus, Maya virus scan/removal; not general antivirus.
+metadata:
+  openclaw:
+    os: [win32]
 ---
 
 # Maya Umbrella batch antivirus
 
 Use this skill only on Windows with the portable `maya_umbrella.exe` CLI and Autodesk Maya scene files. The release bundle embeds its runtime, so do not require or install system Python. Cleanup still requires a locally installed Autodesk Maya version because scene repair runs inside that exact Maya's `mayapy.exe`.
+
+## Interpret requests
+
+- Treat `Maya杀毒`, `Maya病毒扫描`, `Maya病毒查杀`, `清理Maya病毒`, `Maya antivirus`, `Maya virus scan`, and requests to remove malware from `.ma` or `.mb` scenes as this skill's intent.
+- If the request only says `病毒查杀`, `病毒扫描`, `杀毒`, `virus scan`, `virus removal`, or `antivirus` without Maya, `.ma`, `.mb`, or scene context, ask whether the target is Autodesk Maya scene files. Do not scan, download, or clean anything until that scope is confirmed.
+- Keywords select this skill; they do not authorize cleanup. Treat scan, check, or detect wording as scan-only. For clean, remove, fix, remediate, `杀毒`, or `清理`, scan first and follow the existing findings disclosure and explicit cleanup approval contract.
 
 Before use, run `maya_umbrella.exe --version`, `maya_umbrella.exe scan --help`, and `maya_umbrella.exe clean --help`. Require the batch subcommands plus `--approved-scan-report` and `--approved-scan-report-sha256`. If any capability is absent, stop and install a release containing this contract; do not bypass it with the legacy single-root interface.
 

--- a/tests/test_batch_skill.py
+++ b/tests/test_batch_skill.py
@@ -48,6 +48,69 @@ def test_agent_plugin_and_skill_identity_match_layout():
     assert INSTALL_SCRIPT.is_file()
 
 
+def test_skill_description_exposes_maya_antivirus_intent_in_both_languages():
+    skill_text = (SKILL_ROOT / "SKILL.md").read_text(encoding="utf-8")
+    match = re.search(r"^description: (?P<description>.+)$", skill_text, re.MULTILINE)
+
+    assert match
+    description = match.group("description")
+    assert len(description) <= 220
+    assert all(
+        phrase in description
+        for phrase in (
+            "Maya杀毒",
+            "Maya病毒扫描",
+            "Maya病毒查杀",
+            "清理Maya病毒",
+            "病毒查杀",
+            "Maya antivirus",
+        )
+    )
+    assert "not general antivirus" in description
+    assert all(phrase not in description for phrase in ("恶意脚本检测", "场景清理"))
+    assert "metadata:\n  openclaw:\n    os: [win32]" in skill_text
+
+
+def test_clawhub_release_workflow_uses_pinned_cli_and_catalog_metadata():
+    workflow = (REPOSITORY_ROOT / ".github" / "workflows" / "clawhub-skill.yml").read_text(
+        encoding="utf-8"
+    )
+
+    assert "  release:\n    types: [published]" in workflow
+    assert "github.event_name != 'release' || github.event.release.prerelease == false" in workflow
+    assert "github.event_name == 'pull_request' && github.ref || 'publish'" in workflow
+    assert 'CLAWHUB_CLI_VERSION: "0.23.3"' in workflow
+    assert "npm install --global --ignore-scripts --no-audit --no-fund" in workflow
+    assert '"$(clawhub --cli-version)" == "$CLAWHUB_CLI_VERSION"' in workflow
+    assert '"$(git rev-parse HEAD)" == "$GITHUB_SHA"' in workflow
+    assert '"$(git status --short)"' in workflow
+    assert "npx --yes" not in workflow
+    assert "--categories security,operations" in workflow
+    assert "--topics maya,antivirus,malware,virus-scan,scene-cleanup" in workflow
+    assert 'receipt.status === "unchanged" && receipt.version === receipt.latestVersion' in workflow
+    assert 'receipt.status === "would-publish" && receipt.latestVersion === null' in workflow
+    assert "publish_version=" in workflow
+    assert '--version "$publish_version"' in workflow
+    assert "secrets.CLAWHUB_TOKEN" in workflow
+    assert '"$GITHUB_REF" != "refs/heads/main"' in workflow
+    assert "validate_clawhub_publish.py" in workflow
+    assert 'rm -f -- "$CLAWHUB_CONFIG_PATH"' in workflow
+    assert "clawhub-*.json" not in workflow
+    assert "openclaw/clawhub/.github/workflows/skill-publish.yml" not in workflow
+
+    install_index = workflow.index("- name: Install pinned ClawHub CLI")
+    write_config_index = workflow.index("- name: Write ephemeral ClawHub configuration")
+    publish_index = workflow.index("- name: Preview and optionally publish the Skill")
+    assert install_index < write_config_index < publish_index
+
+    write_config_step = workflow.partition("- name: Write ephemeral ClawHub configuration")[
+        2
+    ].partition("\n      - name:")[0]
+    assert "CLAWHUB_CONFIG_PATH: ${{ runner.temp }}/clawhub-config.json" in write_config_step
+    assert "CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}" in write_config_step
+    assert "process.env.CLAWHUB_CONFIG_PATH" in write_config_step
+
+
 def test_portable_build_pins_the_tested_scanner_engine():
     build_config = (REPOSITORY_ROOT / "pyoxidizer.bzl").read_text(encoding="utf-8")
     project_config = (REPOSITORY_ROOT / "pyproject.toml").read_text(encoding="utf-8")

--- a/tests/test_clawhub_publish.py
+++ b/tests/test_clawhub_publish.py
@@ -1,0 +1,140 @@
+"""Tests for the fail-closed ClawHub publish receipt contract."""
+
+# Import built-in modules
+import importlib.util
+from pathlib import Path
+
+# Import third-party modules
+import pytest
+
+
+SCRIPT_PATH = Path(__file__).parents[1] / ".github" / "scripts" / "validate_clawhub_publish.py"
+SPEC = importlib.util.spec_from_file_location("validate_clawhub_publish", SCRIPT_PATH)
+assert SPEC and SPEC.loader
+VALIDATOR = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(VALIDATOR)
+
+
+def receipt(status):
+    payload = {
+        "ok": True,
+        "status": status,
+        "slug": "maya-umbrella-batch-antivirus",
+        "version": "1.0.0",
+        "latestVersion": "1.0.0" if status == "unchanged" else None,
+        "fileCount": 3,
+        "fingerprint": "a" * 64,
+    }
+    if status == "pending-publication":
+        payload.update(
+            publicationStatus="pending", versionId="version_1", attemptId="attempt_1"
+        )
+    elif status == "published":
+        payload.update(publicationStatus="published", versionId="version_1")
+    elif status == "submitted":
+        payload.update(versionId="version_1")
+    return payload
+
+
+@pytest.mark.parametrize("status", ["unchanged", "would-publish"])
+def test_dry_run_accepts_only_preview_results(status):
+    assert VALIDATOR.validate_receipt(
+        receipt(status), "dry-run", "maya-umbrella-batch-antivirus"
+    )["status"] == status
+
+
+@pytest.mark.parametrize(
+    "status", ["unchanged", "published", "pending-publication", "submitted"]
+)
+def test_publish_accepts_uploaded_and_moderation_pending_results(status):
+    assert VALIDATOR.validate_receipt(
+        receipt(status), "publish", "maya-umbrella-batch-antivirus"
+    )["status"] == status
+
+
+@pytest.mark.parametrize("status", ["would-publish", "failed", "unexpected", None])
+def test_publish_rejects_non_publish_or_unknown_results(status):
+    with pytest.raises(VALIDATOR.ReceiptError, match="not valid for publish"):
+        VALIDATOR.validate_receipt(receipt(status), "publish", "maya-umbrella-batch-antivirus")
+
+
+def test_receipt_identity_and_success_are_required():
+    wrong_slug = receipt("published")
+    wrong_slug["slug"] = "another-skill"
+    with pytest.raises(VALIDATOR.ReceiptError, match="does not match"):
+        VALIDATOR.validate_receipt(wrong_slug, "publish", "maya-umbrella-batch-antivirus")
+
+    failed = receipt("published")
+    failed["ok"] = False
+    with pytest.raises(VALIDATOR.ReceiptError, match="ok=true"):
+        VALIDATOR.validate_receipt(failed, "publish", "maya-umbrella-batch-antivirus")
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("fingerprint", "short", "fingerprint"),
+        ("fileCount", 0, "fileCount"),
+        ("fileCount", True, "fileCount"),
+    ],
+)
+def test_receipt_requires_a_complete_bundle_identity(field, value, message):
+    payload = receipt("would-publish")
+    payload[field] = value
+    with pytest.raises(VALIDATOR.ReceiptError, match=message):
+        VALIDATOR.validate_receipt(payload, "dry-run", "maya-umbrella-batch-antivirus")
+
+
+@pytest.mark.parametrize("latest_version", [None, "0.9.0"])
+def test_unchanged_requires_the_matching_public_latest_version(latest_version):
+    payload = receipt("unchanged")
+    payload["latestVersion"] = latest_version
+    with pytest.raises(VALIDATOR.ReceiptError, match="public latestVersion"):
+        VALIDATOR.validate_receipt(payload, "dry-run", "maya-umbrella-batch-antivirus")
+
+
+@pytest.mark.parametrize(
+    ("status", "missing_field"),
+    [
+        ("pending-publication", "attemptId"),
+        ("pending-publication", "versionId"),
+        ("published", "versionId"),
+        ("submitted", "versionId"),
+    ],
+)
+def test_publish_receipt_requires_status_specific_evidence(status, missing_field):
+    payload = receipt(status)
+    del payload[missing_field]
+    with pytest.raises(VALIDATOR.ReceiptError, match=missing_field):
+        VALIDATOR.validate_receipt(payload, "publish", "maya-umbrella-batch-antivirus")
+
+
+@pytest.mark.parametrize(
+    ("status", "publication_status"),
+    [("pending-publication", "published"), ("published", "pending")],
+)
+def test_publish_receipt_rejects_a_mismatched_publication_status(
+    status, publication_status
+):
+    payload = receipt(status)
+    payload["publicationStatus"] = publication_status
+    with pytest.raises(VALIDATOR.ReceiptError, match="publicationStatus"):
+        VALIDATOR.validate_receipt(payload, "publish", "maya-umbrella-batch-antivirus")
+
+
+@pytest.mark.parametrize("field", ["version", "fingerprint", "fileCount"])
+def test_publish_receipt_must_match_the_preview(field):
+    preview = receipt("would-publish")
+    published = receipt("published")
+    published[field] = {
+        "version": "1.0.1",
+        "fingerprint": "b" * 64,
+        "fileCount": 4,
+    }[field]
+    with pytest.raises(VALIDATOR.ReceiptError, match=f"{field} does not match"):
+        VALIDATOR.validate_receipt(
+            published,
+            "publish",
+            "maya-umbrella-batch-antivirus",
+            preview,
+        )


### PR DESCRIPTION
## Summary
- publish stable releases with pinned ClawHub 0.23.3 and fail-closed receipts
- serialize and restrict real publishes while keeping credentials isolated
- add Chinese/English Maya antivirus routing phrases and Windows gating

## Validation
- 103 tests passed
- Ruff, isort, actionlint, and Skill validation passed
- ClawHub dry-run: would-publish 1.0.0 (3 files)

## Follow-up
- configure the repository CLAWHUB_TOKEN before the first main publish