### PR TITLE
docs: add bilingual README and improve GEO discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,94 @@
-# maya_umbrella_scanner
+# Maya Umbrella Scanner — Autodesk Maya Scene Malware Scanner
 
-面向 Windows 的便携式 Maya 场景病毒扫描与清理 CLI。发布包通过 PyOxidizer 内嵌运行时，用户机器不需要安装系统 Python；清理仍需要本机已安装的 Autodesk Maya，因为场景修复必须在所选版本的 `mayapy.exe` 和 Maya API 中执行。
+[English](README.md) | [简体中文](README.zh-CN.md)
+
+`maya_umbrella_scanner` is a portable Windows x64 CLI and Agent Skill for batch scanning and approval-gated cleanup of known malware in Autodesk Maya `.ma` and `.mb` scene files.
 
 > [!TIP]
-> **现已支持 Agent Skills。** 将 `maya-umbrella-batch-antivirus` 安装到 Codex、WorkBuddy 等支持 Agent Skills 的 Agent 后，即可用自然语言发起 Maya 场景病毒扫描与受控清理。Skill 会串联批量扫描、明确授权、备份校验和清理后复扫，让病毒查杀更高效、更安全。详见 [Agent Skill](#agent-skill)。
+> **Agent Skills are supported.** If your Codex, WorkBuddy, or another client version supports Agent Skills, install `maya-umbrella-batch-antivirus` and request a Maya virus scan in natural language. The Skill coordinates scope confirmation, batch scanning, findings disclosure, explicit cleanup approval, backup verification, and an independent post-clean scan. This can reduce manual sequencing while preserving the safety gates.
 
-## 安装
+## What is Maya Umbrella Scanner?
 
-从 [GitHub Releases](https://github.com/loonghao/maya_umbrella_scanner/releases) 下载精确版本的 `maya_umbrella_scanner-<version>.zip` 和同一 Release 的 `SHA256SUMS`。校验 ZIP 的 SHA-256 后完整解压，保留 `maya_umbrella.exe`、`bin` 和 `lib` 的相对目录结构。它是一个无需外部 Python 的便携 CLI 包，不是单独一个可脱离配套文件运行的 PE。
+Maya Umbrella Scanner is a batch Maya virus scanner and controlled Maya antivirus workflow for Windows x64. It recursively checks exact directories for known signatures in Maya scene files. Scan mode does not launch Maya or rewrite scenes. Cleanup runs only after the findings are disclosed and approved, then uses the selected local Maya installation's `mayapy.exe` and Maya API to repair affected scenes.
 
-安装 Agent Skill 后，也可以让 Agent 在取得精确版本和下载位置的批准后运行 Skill 自带的校验安装器：
+The PyOxidizer release bundle embeds its Python runtime, so scanning does not require system Python. Cleanup still requires the exact Autodesk Maya year selected for the operation.
+
+> [!IMPORTANT]
+> This project handles Maya `.ma` and `.mb` scene malware. It is not a general system antivirus, and a clean scene report does not prove that Maya startup directories, the Maya installation, referenced files, or the rest of Windows are clean.
+
+## Project components
+
+| Name | Role |
+| --- | --- |
+| Maya Umbrella Scanner / `maya_umbrella_scanner` | Product and repository name |
+| `maya_umbrella.exe` | Portable Windows x64 batch CLI |
+| `maya-umbrella-scanner` | Agent Plugin name declared by [`plugin.json`](plugin.json) |
+| `maya-umbrella-batch-antivirus` | Installable [Agent Skill](skills/maya-umbrella-batch-antivirus/SKILL.md) |
+
+## Key capabilities
+
+- Scan multiple explicitly selected directories in one run by repeating `--path`.
+- Recursively inspect Maya `.ma` and `.mb` files without starting Maya in scan mode.
+- Bind cleanup authorization to the same executable, target set, report bytes, infected paths, and source SHA-256 values.
+- Create verified, no-clobber backups in adjacent `_virus` directories before any scene rewrite.
+- Isolate Maya cleanup from existing startup hooks and finish with full-scope plus independent post-clean scans.
+- Let Agent Skills-compatible clients, including supported Codex or WorkBuddy versions, orchestrate the workflow through a bounded Agent Skill.
+
+## Requirements
+
+| Task | Requirements |
+| --- | --- |
+| Scan | Windows x64 release bundle. No system Python or Autodesk Maya installation is required. |
+| Cleanup | The same release bundle plus a local Autodesk Maya installation for the explicitly selected year. |
+| Skill installation with `npx` | Node.js and npm are required only for this installation method, not for the scanner runtime. |
+| Skill-local CLI installer | Windows PowerShell 5.1 or later, `%LOCALAPPDATA%`, and the current non-administrator user. |
+
+## Installation
+
+### Install the Agent Skill
+
+Use the Skills CLI to install the repository's Skill. This example targets a global Codex installation; omit `--global` for project-level installation:
+
+```powershell
+npx --yes skills@1.5.23 add loonghao/maya_umbrella_scanner `
+  --skill maya-umbrella-batch-antivirus `
+  --agent codex `
+  --global `
+  --yes
+```
+
+For an Agent Skills-compatible WorkBuddy or another agent, import the same `maya-umbrella-batch-antivirus` Skill through that client's supported Skills entrypoint. The command above is specifically a Codex example.
+
+If a compatible CLI is not installed, the Skill first shows the exact repository, release version, ZIP asset, checksum asset, and destination. After you approve that download, it runs its verified installer with the exact version:
 
 ```powershell
 & "<skill-directory>\scripts\install_cli.ps1" -Version "<approved-version>"
 ```
 
-安装器不会隐式选择 `latest`，不会覆盖已安装版本，并以 JSON 返回已验证的 `maya_umbrella.exe` 路径。它固定安装到 `%LOCALAPPDATA%\maya_umbrella_scanner\versions\<version>`，应以当前用户运行，不要使用提权的管理员 PowerShell。
+The installer never selects `latest`, never overwrites an installed version, and returns the verified `maya_umbrella.exe` path as JSON. It installs to `%LOCALAPPDATA%\maya_umbrella_scanner\versions\<version>`. Run it as the current user, not from an elevated administrator PowerShell.
 
-## 用法
+### Install the portable CLI manually
 
-先确认便携 CLI 具备批量安全契约：
+Download the exact `maya_umbrella_scanner-<version>.zip` and `SHA256SUMS` from the same [GitHub Release](https://github.com/loonghao/maya_umbrella_scanner/releases). Verify the ZIP's SHA-256, then extract the complete archive.
+
+Keep the relative layout of `maya_umbrella.exe`, `bin`, and `lib`. The archive is a portable CLI bundle, not a standalone PE that can be separated from its companion files.
+
+## How to scan and clean Maya scene malware
+
+### Use an Agent Skills-compatible client (Codex, WorkBuddy, or another agent)
+
+After installing the Skill, submit a bounded natural-language request:
+
+```text
+Use the maya-umbrella-batch-antivirus Skill to scan C:\project\scenes for Maya scene malware.
+Show me the findings and report first. Do not clean anything without my explicit approval.
+```
+
+Intent selects the Skill; it does not authorize cleanup. Even when the request says “clean,” “remove,” or “antivirus,” the Skill scans first, discloses the exact findings and side effects, and waits for explicit approval.
+
+### Verify the CLI contract
+
+Require the batch commands and approval arguments introduced with the v0.2.0 batch contract. Probe capabilities instead of trusting a version string alone:
 
 ```powershell
 .\maya_umbrella.exe --version
@@ -27,9 +96,11 @@
 .\maya_umbrella.exe clean --help
 ```
 
-### 病毒扫描
+The executable must expose `scan`, `clean`, `--approved-scan-report`, and `--approved-scan-report-sha256`. The Skill must reject releases without that contract, including v0.1.8 and earlier, and must never fall back to the legacy single-root interface.
 
-重复 `--path` 可以扫描多个目录。程序递归检查目录下的 `.ma` 和 `.mb` 文件；扫描模式不会启动 Maya 或改写场景。
+### Scan Maya scenes
+
+Repeat `--path` to scan multiple exact directories. Every supplied `--report` must be a fresh, not-yet-existing `.json` path. A report is required when cleanup may follow:
 
 ```powershell
 .\maya_umbrella.exe scan `
@@ -38,11 +109,13 @@
   --report "C:\temp\maya-umbrella-scan.json"
 ```
 
-命中时，JSON 报告记录文件路径与源 SHA-256；stdout 中的 `report_file_sha256` 绑定报告的精确字节。计划清理时必须把报告、摘要、命中文件和目标范围一起交给用户明确批准。
+The report records each infected path and source SHA-256. The stdout JSON contains `report_file_sha256`, which binds the exact report bytes. Before cleanup, disclose the resolved roots, scanner path and version, infected-file list, source hashes, report digest, selected Maya year, and cleanup side effects.
 
-### 自动杀毒
+Scan mode does not start Maya or rewrite scenes, although it may create temporary output and the requested report. A scan can cover an unusually broad root only after that exact scope is confirmed.
 
-清理必须使用同一个 CLI、同一组路径、用户批准的原始报告与摘要，并指定本机 Maya 年份：
+### Clean only after explicit approval
+
+After the user approves the disclosed findings and effects, use the same executable, the same paths, the unchanged approved report and digest, and one explicitly selected Maya year:
 
 ```powershell
 .\maya_umbrella.exe clean `
@@ -55,45 +128,50 @@
   --report "C:\temp\maya-umbrella-clean.json"
 ```
 
-没有批准证据的直接 `--maya-version` 调用会失败关闭。`--confirm-clean` 只是命令行门禁，不能代替用户对具体范围和副作用的知情批准。
+`--confirm-clean` is a CLI guard, not a substitute for informed approval of the exact scope and side effects. The cleanup target can never be a drive root or the user's home directory, even if requested. Cleanup also rejects symlinks, junctions, and reparse points.
 
-清理会先把原场景备份到相邻的 `_virus` 目录，再原地保存修复后的场景，并在结束前重新扫描。请勿设置 `MAYA_UMBRELLA_IGNORE_BACKUP=true`。
+Cleanup force-saves repaired scenes in place after staging and verifying adjacent `_virus` backups. It stops on drift, backup collision, identity alias, hash mismatch, insufficient evidence, or an indeterminate target.
 
-Maya 打开场景后若以无回调的只读检查发现感染的引用文件，或发现批准场景清单之外的 Maya/Python 文件，本次清理会在场景改写前中止，并要求建立新的明确范围；清理引擎不会改写批准清单外的文件。
-
-Maya 2019–2021 的 Python 2 无法通过当前引擎安全保存非 ASCII 场景路径；受控清理会在备份或启动 Maya 前拒绝该组合。不要在批准后移动或重命名文件；如改用其他 Maya 版本，必须重新扫描并批准。
-
-## Agent Skill
-
-仓库根目录遵循 [Agent Plugins 1.0](https://agent-plugins.org/specification)：`plugin.json` 描述完整插件包，`skills/maya-umbrella-batch-antivirus` 是可独立安装的 [Agent Skill](https://agentskills.io/specification)。Agent Plugins 规范只定义包格式，不规定安装或发布服务。
-
-使用通用 Skills CLI 从 GitHub 安装指定 Skill。以下命令以 Codex 全局安装为例（项目级安装请去掉 `--global`）；WorkBuddy 等其他 Agent 请通过其支持的 Skills 安装入口导入同一个 Skill：
+Ensure no interactive Maya session is editing the target scenes during cleanup. After cleanup, run one additional independent scan with the same executable and paths and a third fresh report:
 
 ```powershell
-npx --yes skills@1.5.23 add loonghao/maya_umbrella_scanner `
-  --skill maya-umbrella-batch-antivirus `
-  --agent codex `
-  --global `
-  --yes
+.\maya_umbrella.exe scan `
+  --path "C:\project\scenes" `
+  --path "D:\shots\asset" `
+  --report "C:\temp\maya-umbrella-post-clean-scan.json"
 ```
 
-安装后，在 Codex、WorkBuddy 等 Agent 中直接提出自然语言请求，例如：
+Call the active scene scope clean only when cleanup completed without an indeterminate target, expected backups exist, the CLI's full-scope final scan succeeded, and the independent post-clean scan reports no remaining signatures.
 
-```text
-请扫描 C:\project\scenes 中的 Maya 场景病毒；先向我展示命中项和报告，未经我明确批准不要清理。
-```
+## Safety contract
 
-Skill 提供批量目录扫描、显式清理授权、备份哈希核验和清理后复扫。它只处理 Maya `.ma`/`.mb` 场景，不是通用系统杀毒软件。实际执行流程与风险边界见 `skills/maya-umbrella-batch-antivirus/SKILL.md`。
+The authoritative workflow is defined in the [Agent Skill](skills/maya-umbrella-batch-antivirus/SKILL.md) and its [operation contract](skills/maya-umbrella-batch-antivirus/references/operation-contract.md). The essential guarantees are:
 
-Agent 必须确认 `scan`/`clean` 子命令和两个批准参数都存在。v0.1.8 及更早版本不具备完整批量清理门禁，只能按旧版能力使用；Skill 会让不兼容版本在任何 Maya 场景被修改前失败关闭。每次 `--report` 都应使用一个尚不存在的 `.json` 路径，以保留独立审计证据；scan 在 stdout 输出的 `report_file_sha256` 必须与命中清单一起交给用户批准，并原样传给 clean。
+- Approval binds the scanner path, target set, report bytes, infected paths, and source hashes. The Maya year is an additional explicit cleanup parameter and approval item.
+- `_virus` is the fixed backup/quarantine directory. Do not set `MAYA_UMBRELLA_IGNORE_BACKUP=true` or customize `MAYA_UMBRELLA_BACKUP_FOLDER_NAME`.
+- Signature scans exclude `_virus`, which may contain infected original scene bytes. Preserve and quarantine those backups accordingly; a clean result does not prove the backup directory is clean.
+- Existing same-name backups are never overwritten. Preserve or relocate them only with approval, then scan again.
+- Cleanup pre-creates an empty `Maya.env`, uses an isolated temporary `MAYA_APP_DIR`, and disables Python user-site.
+- Existing `Maya.env`, `userSetup.py`, `userSetup.mel`, `.pth`, `sitecustomize.py`, module paths, plug-in paths, and custom script paths are not executed or deleted.
+- Infected references or Maya/Python files outside the approved scene manifest abort cleanup before scene modification. They require a separate scope and approval.
+- `indeterminate` is a failure state, never a clean result. A successful cleanup exit code alone is not sufficient verification.
 
-为避免把任意现有项目子树从扫描范围隐藏，备份/隔离目录固定为 `_virus`。自定义 `MAYA_UMBRELLA_BACKUP_FOLDER_NAME` 现会失败关闭；这是新版的安全性 breaking change。
+## Compatibility and limitations
 
-清理进程会预建空的 `Maya.env`，使用临时隔离的 `MAYA_APP_DIR`，并禁用 Python user-site；不会执行用户现有的 `Maya.env`、`userSetup.py`、`userSetup.mel`、`.pth`/`sitecustomize.py` 或自定义启动路径。只读检查可以报告相关 Maya/Python 目录中的匹配文件，但不会删除它们；这类文件需要另行批准检查和隔离，不能从场景复扫结果推断为安全。
+- The portable release targets Windows x64.
+- Scan mode does not require Maya. Cleanup requires the exact locally installed Maya year selected for that run.
+- Maya 2019–2021 use Python 2 and cannot safely save non-ASCII scene paths through the current engine. The CLI refuses that combination before backup or Maya startup.
+- Do not move, rename, or copy scenes after approval to work around a path failure. Selecting another Maya year requires a fresh scan and approval.
+- Saving through a newer Maya version can change scene compatibility.
+- The scanner detects the known signatures supported by its pinned engine; it does not provide a general malware-analysis guarantee.
+
+## Agent Plugin and Skill distribution
+
+The repository follows [Agent Plugins 1.0](https://agent-plugins.org/specification). [`plugin.json`](plugin.json) is the package manifest, and compatible clients discover the standalone [`skills/maya-umbrella-batch-antivirus/SKILL.md`](skills/maya-umbrella-batch-antivirus/SKILL.md) entrypoint from the fixed `skills/` layout. The Agent Plugins specification defines packaging, not a required installation or publishing service.
 
 ### ClawHub
 
-ClawHub 分发的是 Skill 子目录，不是仅含根 `plugin.json` 的完整 Agent Plugins 包。发布前先做 dry-run：
+ClawHub distributes the Skill directory rather than a package containing only the root manifest. Maintainers can validate a prospective publication with a pinned dry run:
 
 ```powershell
 npx --yes clawhub@0.23.3 skill publish .\skills\maya-umbrella-batch-antivirus `
@@ -104,16 +182,46 @@ npx --yes clawhub@0.23.3 skill publish .\skills\maya-umbrella-batch-antivirus `
   --json
 ```
 
-正式发布前先执行 `npx --yes clawhub@0.23.3 login`。仓库配置 `CLAWHUB_TOKEN` secret 后，每个正式（非 prerelease）GitHub Release 会自动运行 `ClawHub Skill` workflow；`workflow_dispatch` 仅允许从 `main` 手动首发或受控补发。工作流固定使用 ClawHub CLI 0.23.3，首次发布时设置 `security,operations` 分类与检索 topics，后续同步省略这两个参数以保持内容未变化时的幂等性。它保存结构化回执，并把 `pending-publication` 或 `submitted` 作为“已提交、等待公开验证”，而不是误报成上传失败。公开版本通过安全审核并可见后，可通过 CLI 安装：
+Run `npx --yes clawhub@0.23.3 login` before an authorized publication. With a configured `CLAWHUB_TOKEN` secret, every non-prerelease GitHub Release triggers the `ClawHub Skill` workflow; `workflow_dispatch` is restricted to `main` for a controlled initial or recovery publication. The workflow pins ClawHub CLI 0.23.3 and preserves structured receipts. A `pending-publication` or `submitted` receipt means the registry workflow accepted or recorded the submission, but public availability has not yet been verified.
+
+After a public version is confirmed visible, install it with:
 
 ```powershell
 openclaw skills install @loonghao/maya-umbrella-batch-antivirus
-# 或使用 ClawHub registry CLI
+# Or use the ClawHub registry CLI
 npx --yes clawhub@0.23.3 install @loonghao/maya-umbrella-batch-antivirus
 ```
 
-## 发布
+## Frequently asked questions
 
-版本与变更日志由 Release Please 从 Conventional Commits 统一维护。它同步 `pyproject.toml`、`maya_umbrella_scanner/__version__.py`、`plugin.json` 和 manifest，创建 `vX.Y.Z` 标签及 GitHub Release。标签工作流使用固定构建工具生成 Windows 便携包与 `SHA256SUMS`，只向 Release Please 已创建的 Release 附加资产。重跑不会覆盖已有资产；若上一次只成功上传 ZIP，会为该 ZIP 的确切字节补传校验文件，已有 ZIP 与校验文件不一致则失败关闭。
+### Can an Agent Skills-compatible Codex or WorkBuddy scan and clean Maya scene malware?
 
-运行时架构及没有直接全面改写 Rust 的原因见 [ADR 0001](docs/adr/0001-portable-cli-runtime.md)。
+Yes, when that client version supports Agent Skills and can access the Windows CLI. Install `maya-umbrella-batch-antivirus`, then ask it to scan an exact directory. Controlled cleanup still requires findings disclosure and explicit approval after the scan. The repository validates Skill discovery and the bounded workflow; it does not claim end-to-end validation for every Agent client version.
+
+### Does scanning modify Maya files?
+
+No. Scan mode does not launch Maya or rewrite scenes. It may write temporary output and a requested JSON report. Cleanup is a separate, approval-gated operation that force-saves repaired scenes after verified backups are staged.
+
+### Does it require Python or Autodesk Maya?
+
+The portable release embeds its Python runtime, so neither scanning nor cleanup requires system Python. Scanning does not require Maya. Cleanup requires the exact selected Autodesk Maya year because repair runs through that installation's `mayapy.exe` and Maya API.
+
+### Does it clean `userSetup.py` or the entire Maya installation?
+
+No. Read-only discovery can report matching external Maya/Python files, but this workflow does not delete them. A clean scene scan does not clear startup directories, the Maya installation, infected references, or other external files.
+
+### Is Maya Umbrella Scanner a general antivirus?
+
+No. It is a scoped Maya scene virus scanner for `.ma` and `.mb` files. Keep endpoint protection and broader Maya security controls in place.
+
+## Release and architecture
+
+Release Please owns versions and the changelog. It synchronizes `pyproject.toml`, `maya_umbrella_scanner/__version__.py`, `plugin.json`, and the release manifest, then creates a `vX.Y.Z` tag and GitHub Release. The tag workflow uses pinned build tools to produce the Windows portable ZIP and `SHA256SUMS`.
+
+Reruns never overwrite existing release assets. If an earlier run uploaded only the ZIP, a rerun can add the checksum for those exact bytes; a mismatch between an existing ZIP and checksum fails closed.
+
+See [ADR 0001](docs/adr/0001-portable-cli-runtime.md) for the runtime architecture and the decision not to perform an immediate full Rust rewrite.
+
+## License
+
+Maya Umbrella Scanner is released under the [MIT License](LICENSE).

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 面向 Windows 的便携式 Maya 场景病毒扫描与清理 CLI。发布包通过 PyOxidizer 内嵌运行时，用户机器不需要安装系统 Python；清理仍需要本机已安装的 Autodesk Maya，因为场景修复必须在所选版本的 `mayapy.exe` 和 Maya API 中执行。
 
+> [!TIP]
+> **现已支持 Agent Skills。** 将 `maya-umbrella-batch-antivirus` 安装到 Codex、WorkBuddy 等支持 Agent Skills 的 Agent 后，即可用自然语言发起 Maya 场景病毒扫描与受控清理。Skill 会串联批量扫描、明确授权、备份校验和清理后复扫，让病毒查杀更高效、更安全。详见 [Agent Skill](#agent-skill)。
+
 ## 安装
 
 从 [GitHub Releases](https://github.com/loonghao/maya_umbrella_scanner/releases) 下载精确版本的 `maya_umbrella_scanner-<version>.zip` 和同一 Release 的 `SHA256SUMS`。校验 ZIP 的 SHA-256 后完整解压，保留 `maya_umbrella.exe`、`bin` 和 `lib` 的相对目录结构。它是一个无需外部 Python 的便携 CLI 包，不是单独一个可脱离配套文件运行的 PE。
@@ -64,7 +67,7 @@ Maya 2019–2021 的 Python 2 无法通过当前引擎安全保存非 ASCII 场�
 
 仓库根目录遵循 [Agent Plugins 1.0](https://agent-plugins.org/specification)：`plugin.json` 描述完整插件包，`skills/maya-umbrella-batch-antivirus` 是可独立安装的 [Agent Skill](https://agentskills.io/specification)。Agent Plugins 规范只定义包格式，不规定安装或发布服务。
 
-使用通用 Skills CLI 从 GitHub 安装指定 Skill（项目级安装请去掉 `--global`）：
+使用通用 Skills CLI 从 GitHub 安装指定 Skill。以下命令以 Codex 全局安装为例（项目级安装请去掉 `--global`）；WorkBuddy 等其他 Agent 请通过其支持的 Skills 安装入口导入同一个 Skill：
 
 ```powershell
 npx --yes skills@1.5.23 add loonghao/maya_umbrella_scanner `
@@ -72,6 +75,12 @@ npx --yes skills@1.5.23 add loonghao/maya_umbrella_scanner `
   --agent codex `
   --global `
   --yes
+```
+
+安装后，在 Codex、WorkBuddy 等 Agent 中直接提出自然语言请求，例如：
+
+```text
+请扫描 C:\project\scenes 中的 Maya 场景病毒；先向我展示命中项和报告，未经我明确批准不要清理。
 ```
 
 Skill 提供批量目录扫描、显式清理授权、备份哈希核验和清理后复扫。它只处理 Maya `.ma`/`.mb` 场景，不是通用系统杀毒软件。实际执行流程与风险边界见 `skills/maya-umbrella-batch-antivirus/SKILL.md`。

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,227 @@
+# Maya Umbrella Scanner — Autodesk Maya 场景病毒扫描器
+
+[English](README.md) | [简体中文](README.zh-CN.md)
+
+`maya_umbrella_scanner` 是面向 Windows x64 的便携式 CLI 与 Agent Skill，用于批量扫描 Autodesk Maya `.ma` 和 `.mb` 场景中的已知恶意代码，并在获得批准后执行受控清理。
+
+> [!TIP]
+> **已支持 Agent Skills。** 如果所用 Codex、WorkBuddy 或其他客户端版本支持 Agent Skills，即可安装 `maya-umbrella-batch-antivirus` 并用自然语言发起 Maya 病毒扫描。Skill 会串联范围确认、批量扫描、命中披露、明确清理授权、备份校验和独立的清理后复扫，可以在保留安全门禁的同时减少手工步骤。
+
+## Maya Umbrella Scanner 是什么？
+
+Maya Umbrella Scanner 是面向 Windows x64 的批量 Maya 病毒扫描器与受控 Maya 病毒查杀流程。它递归检查用户精确指定的目录，查找 Maya 场景文件中的已知病毒特征。扫描模式不会启动 Maya 或改写场景。只有在披露并批准命中项后，清理流程才会通过所选本地 Maya 安装的 `mayapy.exe` 和 Maya API 修复受影响的场景。
+
+PyOxidizer 发布包内嵌 Python 运行时，因此扫描不需要系统 Python。清理仍需要本机安装本次操作明确选择的 Autodesk Maya 年份。
+
+> [!IMPORTANT]
+> 本项目只处理 Maya `.ma` 和 `.mb` 场景病毒，不是通用系统杀毒软件。场景扫描结果干净，也不能证明 Maya 启动目录、Maya 安装、引用文件或 Windows 其他位置没有问题。
+
+## 项目组成
+
+| 名称 | 作用 |
+| --- | --- |
+| Maya Umbrella Scanner / `maya_umbrella_scanner` | 产品与仓库名称 |
+| `maya_umbrella.exe` | Windows x64 便携式批量 CLI |
+| `maya-umbrella-scanner` | [`plugin.json`](plugin.json) 声明的 Agent Plugin 名称 |
+| `maya-umbrella-batch-antivirus` | 可安装的 [Agent Skill](skills/maya-umbrella-batch-antivirus/SKILL.md) |
+
+## 核心能力
+
+- 通过重复 `--path`，一次扫描多个明确选择的目录。
+- 在扫描模式下递归检查 Maya `.ma` 和 `.mb` 文件，不启动 Maya。
+- 将清理授权绑定到同一可执行文件、目标集合、报告字节、感染路径和源文件 SHA-256。
+- 在改写任何场景前，先在相邻 `_virus` 目录建立经过验证且不可覆盖的备份。
+- 将 Maya 清理与现有启动钩子隔离，并以全范围终检和独立的清理后复扫结束流程。
+- 允许支持 Agent Skills 的客户端（包括具备该能力的 Codex 或 WorkBuddy 版本）通过边界明确的 Agent Skill 编排完整流程。
+
+## 环境要求
+
+| 任务 | 要求 |
+| --- | --- |
+| 扫描 | Windows x64 发布包；不需要系统 Python 或 Autodesk Maya。 |
+| 清理 | 同一个发布包，以及本机安装的、此次操作明确选择年份的 Autodesk Maya。 |
+| 使用 `npx` 安装 Skill | 仅此安装方式需要 Node.js 和 npm，扫描器运行时不需要。 |
+| 使用 Skill 自带 CLI 安装器 | Windows PowerShell 5.1 或更高版本、`%LOCALAPPDATA%`，并使用当前非管理员用户。 |
+
+## 安装
+
+### 安装 Agent Skill
+
+使用 Skills CLI 安装仓库中的 Skill。以下命令以 Codex 全局安装为例；项目级安装请去掉 `--global`：
+
+```powershell
+npx --yes skills@1.5.23 add loonghao/maya_umbrella_scanner `
+  --skill maya-umbrella-batch-antivirus `
+  --agent codex `
+  --global `
+  --yes
+```
+
+对于支持 Agent Skills 的 WorkBuddy 或其他 Agent，请通过该客户端支持的 Skills 入口导入同一个 `maya-umbrella-batch-antivirus` Skill。上面的命令仅是 Codex 示例。
+
+如果尚未安装兼容 CLI，Skill 会先展示精确仓库、Release 版本、ZIP 资产、校验文件和安装目标。得到下载批准后，它才会用精确版本运行经过校验的安装器：
+
+```powershell
+& "<skill-directory>\scripts\install_cli.ps1" -Version "<approved-version>"
+```
+
+安装器不会选择 `latest`，不会覆盖已安装版本，并以 JSON 返回经过验证的 `maya_umbrella.exe` 路径。它固定安装到 `%LOCALAPPDATA%\maya_umbrella_scanner\versions\<version>`。必须以当前非提权用户运行；禁止从管理员 PowerShell 执行。
+
+### 手动安装便携 CLI
+
+从同一个 [GitHub Release](https://github.com/loonghao/maya_umbrella_scanner/releases) 下载精确版本的 `maya_umbrella_scanner-<version>.zip` 和 `SHA256SUMS`。验证 ZIP 的 SHA-256 后，再完整解压。
+
+必须保留 `maya_umbrella.exe`、`bin` 和 `lib` 的相对目录结构。该压缩包是便携式 CLI 套件，不是可脱离配套文件单独运行的 PE。
+
+## 如何扫描并清理 Maya 场景病毒
+
+### 通过支持 Agent Skills 的客户端使用（Codex、WorkBuddy 等）
+
+安装 Skill 后，提交边界明确的自然语言请求：
+
+```text
+使用 maya-umbrella-batch-antivirus Skill 扫描 C:\project\scenes 中的 Maya 场景病毒。
+先向我展示命中项和报告；未经我明确批准，不要清理任何内容。
+```
+
+意图只用于选择 Skill，并不代表授权清理。即使请求中写了“清理”“删除”或“杀毒”，Skill 也必须先扫描、披露精确命中和副作用，再等待明确批准。
+
+### 验证 CLI 契约
+
+要求 v0.2.0 批量契约引入的批量命令与批准参数。不要只相信版本字符串，必须探测实际能力：
+
+```powershell
+.\maya_umbrella.exe --version
+.\maya_umbrella.exe scan --help
+.\maya_umbrella.exe clean --help
+```
+
+可执行文件必须暴露 `scan`、`clean`、`--approved-scan-report` 和 `--approved-scan-report-sha256`。Skill 必须拒绝缺少该契约的版本（包括 v0.1.8 及更早版本），且绝不能回退到旧版单根目录接口。
+
+### 扫描 Maya 场景
+
+重复 `--path` 可以扫描多个精确目录。每次提供 `--report` 时都必须使用尚不存在的全新 `.json` 路径；后续可能清理时必须生成报告：
+
+```powershell
+.\maya_umbrella.exe scan `
+  --path "C:\project\scenes" `
+  --path "D:\shots\asset" `
+  --report "C:\temp\maya-umbrella-scan.json"
+```
+
+报告记录每个感染路径与源文件 SHA-256。stdout JSON 中的 `report_file_sha256` 绑定报告的精确字节。清理前必须披露解析后的根目录、扫描器路径与版本、感染文件清单、源哈希、报告 SHA-256、所选 Maya 年份和清理副作用。
+
+扫描模式不会启动 Maya 或改写场景，但可能创建临时输出和指定的报告。异常宽泛的扫描根目录只有在该精确范围得到确认后才能使用。
+
+### 仅在获得明确批准后清理
+
+用户批准已披露的命中项和副作用后，使用同一个可执行文件、同一组路径、未经改动的已批准报告及其 `report_file_sha256`，以及一个明确选择的 Maya 年份：
+
+```powershell
+.\maya_umbrella.exe clean `
+  --path "C:\project\scenes" `
+  --path "D:\shots\asset" `
+  --maya-version 2024 `
+  --approved-scan-report "C:\temp\maya-umbrella-scan.json" `
+  --approved-scan-report-sha256 "<approved-report-sha256>" `
+  --confirm-clean `
+  --report "C:\temp\maya-umbrella-clean.json"
+```
+
+`--confirm-clean` 只是 CLI 门禁，不能代替用户对精确范围和副作用的知情批准。即使用户要求，清理目标也不能是盘符根目录或用户主目录。清理还会拒绝符号链接、junction 和 reparse point。
+
+清理会先建立并验证相邻的 `_virus` 备份，再强制原地保存修复后的场景。遇到内容漂移、备份冲突、文件身份别名、哈希不一致、证据不足或 `indeterminate`（无法确定）的目标时，流程会中止。
+
+清理期间不得有交互式 Maya 会话并发编辑目标场景。清理后，还必须使用同一个可执行文件、同一组路径和第三个全新报告，额外执行一次独立扫描：
+
+```powershell
+.\maya_umbrella.exe scan `
+  --path "C:\project\scenes" `
+  --path "D:\shots\asset" `
+  --report "C:\temp\maya-umbrella-post-clean-scan.json"
+```
+
+只有在清理过程中没有 `indeterminate` 目标、预期备份存在、CLI 全范围终检成功，并且独立清理后复扫没有发现剩余特征时，才能称活动场景范围为干净。
+
+## 安全契约
+
+权威流程由 [Agent Skill](skills/maya-umbrella-batch-antivirus/SKILL.md) 及其 [操作契约](skills/maya-umbrella-batch-antivirus/references/operation-contract.md) 定义。核心保证如下：
+
+- 批准绑定扫描器路径、目标集合、报告字节、感染路径和源哈希；Maya 年份是额外的明确清理参数与批准事项。
+- `_virus` 是固定的备份/隔离目录。不要设置 `MAYA_UMBRELLA_IGNORE_BACKUP=true`，也不要自定义 `MAYA_UMBRELLA_BACKUP_FOLDER_NAME`。
+- 特征扫描固定排除 `_virus`，其中可能保留感染场景的原始字节。必须妥善保留并隔离这些备份；活动场景结果干净不代表备份目录干净。
+- 已有同名备份绝不会被覆盖。只有获得批准才能保留或迁移它们，之后必须重新扫描。
+- 清理会预建空的 `Maya.env`，使用隔离的临时 `MAYA_APP_DIR`，并禁用 Python user-site。
+- 现有 `Maya.env`、`userSetup.py`、`userSetup.mel`、`.pth`、`sitecustomize.py`、模块路径、插件路径和自定义脚本路径不会被执行或删除。
+- 感染的引用文件或批准场景清单外的 Maya/Python 文件会让清理在场景修改前中止；它们需要独立范围与批准。
+- `indeterminate` 是失败状态，绝不能当作干净结果。仅有成功的清理退出码不足以完成验证。
+
+## 兼容性与限制
+
+- 便携式发布包面向 Windows x64。
+- 扫描模式不需要 Maya；清理需要本机安装的、本次运行明确选择年份的 Maya。
+- Maya 2019–2021 使用 Python 2，当前引擎无法安全保存非 ASCII 场景路径。CLI 会在备份或启动 Maya 前拒绝该组合。
+- 路径失败后，不得通过移动、重命名或复制场景来绕过批准约束。选择另一个 Maya 年份必须重新扫描并批准。
+- 通过较新 Maya 版本保存可能改变场景兼容性。
+- 扫描器检测固定引擎支持的已知特征，不提供通用恶意代码分析保证。
+
+## Agent Plugin 与 Skill 分发
+
+仓库遵循 [Agent Plugins 1.0](https://agent-plugins.org/specification)。[`plugin.json`](plugin.json) 是包清单，兼容客户端通过固定的 `skills/` 布局发现独立的 [`skills/maya-umbrella-batch-antivirus/SKILL.md`](skills/maya-umbrella-batch-antivirus/SKILL.md) 入口。Agent Plugins 规范定义包结构，不规定必须使用某种安装或发布服务。
+
+### ClawHub
+
+ClawHub 分发 Skill 目录，而不是只含根清单的包。维护者可以使用固定版本的 dry-run 验证待发布内容：
+
+```powershell
+npx --yes clawhub@0.23.3 skill publish .\skills\maya-umbrella-batch-antivirus `
+  --owner loonghao `
+  --categories security,operations `
+  --topics maya,antivirus,malware,virus-scan,scene-cleanup `
+  --dry-run `
+  --json
+```
+
+获得发布授权后，先运行 `npx --yes clawhub@0.23.3 login`。仓库配置 `CLAWHUB_TOKEN` secret 后，每个正式（非 prerelease）GitHub Release 都会触发 `ClawHub Skill` 工作流；`workflow_dispatch` 仅允许从 `main` 进行受控首发或恢复发布。工作流固定使用 ClawHub CLI 0.23.3 并保存结构化回执。`pending-publication` 或 `submitted` 表示 registry 工作流已接受或记录提交，但尚未验证公开可见。
+
+确认公开版本可见后，使用以下命令安装：
+
+```powershell
+openclaw skills install @loonghao/maya-umbrella-batch-antivirus
+# 或使用 ClawHub registry CLI
+npx --yes clawhub@0.23.3 install @loonghao/maya-umbrella-batch-antivirus
+```
+
+## 常见问题
+
+### 支持 Agent Skills 的 Codex 或 WorkBuddy 能扫描并受控清理 Maya 场景病毒吗？
+
+可以，前提是所选客户端版本支持 Agent Skills，并且能够访问 Windows CLI。安装 `maya-umbrella-batch-antivirus` 后，让它扫描一个精确目录即可。受控清理仍必须在扫描后披露命中并取得明确批准。仓库验证了 Skill 发现能力和边界明确的操作流程，但不声称已对每个 Agent 客户端版本完成端到端验证。
+
+### 扫描会修改 Maya 文件吗？
+
+不会。扫描模式不会启动 Maya 或改写场景，但可能写入临时输出和用户要求的 JSON 报告。清理是独立且需要批准的操作，只会在建立经过验证的备份后强制保存修复场景。
+
+### 是否需要 Python 或 Autodesk Maya？
+
+便携式发布包内嵌 Python 运行时，因此扫描和清理都不需要系统 Python。扫描不需要 Maya；清理需要明确选择的 Autodesk Maya 年份，因为修复要通过该安装的 `mayapy.exe` 和 Maya API 执行。
+
+### 它会清理 `userSetup.py` 或整个 Maya 安装吗？
+
+不会。只读发现可以报告匹配的外部 Maya/Python 文件，但该流程不会删除它们。场景扫描结果干净，不能证明启动目录、Maya 安装、感染的引用文件或其他外部文件没有问题。
+
+### Maya Umbrella Scanner 是通用杀毒软件吗？
+
+不是。它是范围限定在 `.ma` 和 `.mb` 文件的 Maya 场景病毒扫描器。请继续使用终端防护和更全面的 Maya 安全措施。
+
+## 发布与架构
+
+Release Please 统一维护版本与变更日志。它同步 `pyproject.toml`、`maya_umbrella_scanner/__version__.py`、`plugin.json` 和发布 manifest，再创建 `vX.Y.Z` 标签与 GitHub Release。标签工作流使用固定构建工具生成 Windows 便携 ZIP 与 `SHA256SUMS`。
+
+重跑不会覆盖已有 Release 资产。若上一次只上传了 ZIP，重跑可以为这些精确字节补传校验文件；已有 ZIP 与校验文件不一致时会失败关闭。
+
+运行时架构以及没有立即全面改写 Rust 的原因见 [ADR 0001](docs/adr/0001-portable-cli-runtime.md)。
+
+## 许可证
+
+Maya Umbrella Scanner 使用 [MIT License](LICENSE)。

--- a/plugin.json
+++ b/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "maya-umbrella-scanner",
   "version": "0.2.0",
-  "description": "Scan and remediate malware in Autodesk Maya scene files on Windows.",
+  "description": "Agent Skill for scanning known malware signatures in Autodesk Maya .ma/.mb scenes with a portable Windows x64 CLI and approval-gated cleanup.",
   "author": {
     "name": "loonghao",
     "email": "hal.long@outlook.com",
@@ -14,8 +14,11 @@
   "keywords": [
     "maya",
     "antivirus",
+    "agent-skills",
     "malware",
     "batch-scanning",
+    "maya-antivirus",
+    "scene-security",
     "windows"
   ]
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "maya-umbrella-scanner"
 version = "0.2.0"
-description = "A portable version for maya umbrella scanner."
+description = "Agent Skill for scanning known malware signatures in Autodesk Maya .ma/.mb scenes with a portable Windows x64 CLI and approval-gated cleanup."
 authors = ["loonghao <hal.long@outlook.com>"]
 license = "MIT"
 readme = "README.md"

--- a/tests/test_batch_skill.py
+++ b/tests/test_batch_skill.py
@@ -71,6 +71,53 @@ def test_skill_description_exposes_maya_antivirus_intent_in_both_languages():
     assert "metadata:\n  openclaw:\n    os: [win32]" in skill_text
 
 
+def test_public_metadata_and_bilingual_readmes_share_discovery_contract():
+    english = (REPOSITORY_ROOT / "README.md").read_text(encoding="utf-8")
+    chinese = (REPOSITORY_ROOT / "README.zh-CN.md").read_text(encoding="utf-8")
+    plugin = json.loads((REPOSITORY_ROOT / "plugin.json").read_text(encoding="utf-8"))
+    project_config = (REPOSITORY_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+
+    assert "[简体中文](README.zh-CN.md)" in english
+    assert "[English](README.md)" in chinese
+
+    shared_contract = (
+        "maya_umbrella_scanner",
+        "maya_umbrella.exe",
+        "maya-umbrella-scanner",
+        "maya-umbrella-batch-antivirus",
+        "--approved-scan-report",
+        "--approved-scan-report-sha256",
+        "--confirm-clean",
+        "report_file_sha256",
+        "_virus",
+        "MAYA_UMBRELLA_IGNORE_BACKUP=true",
+        "skills/maya-umbrella-batch-antivirus/SKILL.md",
+        "skills/maya-umbrella-batch-antivirus/references/operation-contract.md",
+    )
+    assert all(term in english and term in chinese for term in shared_contract)
+
+    powershell_block = re.compile(r"^```powershell\n(?P<body>.*?)^```", re.MULTILINE | re.DOTALL)
+
+    def commands_without_translated_comments(text):
+        return [
+            "\n".join(line for line in match.group("body").splitlines() if not line.startswith("#")).strip()
+            for match in powershell_block.finditer(text)
+        ]
+
+    assert commands_without_translated_comments(english) == commands_without_translated_comments(chinese)
+
+    project_description = re.search(
+        r'^description = "(?P<description>.+)"$', project_config, re.MULTILINE
+    )
+    assert project_description
+    assert plugin["description"] == project_description.group("description")
+    assert all(
+        phrase in plugin["description"]
+        for phrase in ("Agent Skill", "known malware signatures", "Autodesk Maya", "Windows x64")
+    )
+    assert {"agent-skills", "maya-antivirus", "scene-security"} <= set(plugin["keywords"])
+
+
 def test_clawhub_release_workflow_uses_pinned_cli_and_catalog_metadata():
     workflow = (REPOSITORY_ROOT / ".github" / "workflows" / "clawhub-skill.yml").read_text(
         encoding="utf-8"


### PR DESCRIPTION
## Summary
- make the English README the default and add an equivalent Simplified Chinese README
- document the Agent Skills workflow for compatible clients while preserving cleanup safety boundaries
- align plugin and package discovery metadata and add bilingual parity tests

## Validation
- `nox -s lint`
- `nox -s pytest` (104 passed)
- `npx --yes skills@1.5.23 add . --list`
- `poetry check`
- Agent Plugins schema, Markdown links, and bilingual command parity